### PR TITLE
Set a default value for the price in the reparation requests table

### DIFF
--- a/db/migrate/20210421214903_change_price_default_value_in_reparation_request.rb
+++ b/db/migrate/20210421214903_change_price_default_value_in_reparation_request.rb
@@ -1,0 +1,5 @@
+class ChangePriceDefaultValueInReparationRequest < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :reparation_requests, :price, from: nil, to: 0.0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_21_204009) do
+ActiveRecord::Schema.define(version: 2021_04_21_214903) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 2021_04_21_204009) do
     t.string "requester_city"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.decimal "price"
+    t.decimal "price", default: "0.0"
     t.index ["store_id"], name: "index_reparation_requests_on_store_id"
   end
 


### PR DESCRIPTION
Generate a migration to set with 0.0 as defaufault value for the price in the reparation_request table.