### PR TITLE
Add index method in the reparation requests controller

### DIFF
--- a/app/controllers/reparation_requests_controller.rb
+++ b/app/controllers/reparation_requests_controller.rb
@@ -1,4 +1,11 @@
 class ReparationRequestsController < ApplicationController
+  def index
+    return redirect_to new_reparation_request_path new unless current_user
+
+    @store = Store.find(current_user[:store_id])
+    @reparation_requests = @store.reparation_requests
+  end
+
   def new
     @reparation_request = ReparationRequest.new
   end


### PR DESCRIPTION
Add index method in the reparation requests controller to be able retrieve all the reparation requests that belongs to a specific store when the current_user exists.

![Captura de pantalla de 2021-04-23 13-35-44](https://user-images.githubusercontent.com/65042074/115915411-eb6f5d00-a438-11eb-81be-50af02194afa.png)
